### PR TITLE
fix: drop sudo requirement and bump default apko version

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -3,9 +3,13 @@ parameters:
   caching:
     type: boolean
     default: true
+  install_path:
+    type: string
+    default: "/home/circleci/bin"
+    description: Path to a binary directory not requiring root access (no trailing slash).
   version:
     type: string
-    default: "0.14.0"
+    default: "0.17.0"
     description: Specify the semver of the Apko version to install.
 steps:
   - when:
@@ -16,6 +20,7 @@ steps:
   - run:
       name: Install Apko << parameters.version >>
       environment:
+        PARAM_INSTALL_PATH: << parameters.install_path >>
         PARAM_VERSION: << parameters.version >>
       command: << include(scripts/install.sh) >>
   - when:

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -2,12 +2,25 @@
 
 set -e
 
+# Ensure CircleCI environment variables can be passed in as orb parameters
+INSTALL_PATH=$(circleci env subst "${PARAM_INSTALL_PATH}")
+VERSION=$(circleci env subst "${PARAM_VERSION}")
+
+# Check if the apko tar file was in the CircleCI cache.
+# Cache restoration is handled in install.yml
 if [[ -f apko.tar.gz ]]; then
-    tar zxvf apko.tar.gz "apko_${PARAM_VERSION}_linux_amd64/apko" --strip 1
+    tar zxvf apko.tar.gz "apko_${VERSION}_linux_amd64/apko" --strip 1
 fi
+
+# If there was no cache hit, go ahead and re-download the binary.
 if [[ ! -f apko ]]; then
-    wget "https://github.com/chainguard-dev/apko/releases/download/v${PARAM_VERSION}/apko_${PARAM_VERSION}_linux_amd64.tar.gz" -O apko.tar.gz
-    tar zxvf apko.tar.gz "apko_${PARAM_VERSION}_linux_amd64/apko" --strip 1
+    wget "https://github.com/chainguard-dev/apko/releases/download/v${VERSION}/apko_${VERSION}_linux_amd64.tar.gz" -O apko.tar.gz
+    tar zxvf apko.tar.gz "apko_${VERSION}_linux_amd64/apko" --strip 1
 fi
-sudo mv apko /usr/local/bin/apko
-sudo chmod +x /usr/local/bin/apko
+
+# An apko binary should exist at this point, regardless of whether it was obtained
+# through cache or re-downloaded. Move it to an appropriate bin directory and mark it
+# as executable. If your pipeline throws an error here, you may want to choose an
+# INSTALL_PATH that doesn't require sudo access, so this orb can avoid any root actions.
+mv apko "${INSTALL_PATH}/apko"
+chmod +x "${INSTALL_PATH}/apko"


### PR DESCRIPTION
- Remove sudo requirement by installing to a different directory by default. For `cimg/*` base images, install to `/home/circleci/bin` instead of `/usr/local/bin`. The new directory is already present in the `$PATH`. Made the install directory customizable.

- Better handling of environment variable expansion through the use of `circleci env subst`.

- Bump default Syft version from 1.0.1 to 1.10.0. The caller can still specify any version they'd like as an argument.